### PR TITLE
Allow running the test suite with GraphQL::Dataloader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 # gem 'graphql', ENV['GRAPHQL_VERSION'] if ENV['GRAPHQL_VERSION']
 gem "graphql", path: "../graphql-ruby"
 gem 'rubocop', '~> 0.78.0', require: false
+gem 'concurrent-ruby', require: 'concurrent'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'graphql', ENV['GRAPHQL_VERSION'] if ENV['GRAPHQL_VERSION']
+# gem 'graphql', ENV['GRAPHQL_VERSION'] if ENV['GRAPHQL_VERSION']
+gem "graphql", path: "../graphql-ruby"
 gem 'rubocop', '~> 0.78.0', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
+  t.warning = false
   t.test_files = FileList['test/**/*_test.rb']
 end
 

--- a/test/batch_test.rb
+++ b/test/batch_test.rb
@@ -1,8 +1,15 @@
 require_relative 'test_helper'
 
 class GraphQL::BatchTest < Minitest::Test
+  def in_batch
+    if TESTING_DATALOADER
+      GraphQL::Dataloader.load { yield }
+    else
+      GraphQL::Batch.batch { yield }
+    end
+  end
   def test_batch
-    product = GraphQL::Batch.batch do
+    product = in_batch do
       RecordLoader.for(Product).load(1)
     end
     assert_equal 'Shirt', product.title
@@ -12,9 +19,9 @@ class GraphQL::BatchTest < Minitest::Test
     promise1 = nil
     promise2 = nil
 
-    product = GraphQL::Batch.batch do
+    product = in_batch do
       promise1 = RecordLoader.for(Product).load(1)
-      GraphQL::Batch.batch do
+      in_batch do
         promise2 = RecordLoader.for(Product).load(1)
       end
       promise1

--- a/test/custom_executor_test.rb
+++ b/test/custom_executor_test.rb
@@ -32,6 +32,17 @@ class GraphQL::Batch::CustomExecutorTest < Minitest::Test
     end
   end
 
+  # TODO This is a hack ...
+  class GraphQL::Execution::Lazy
+    class << self
+      alias :old_sync :sync
+      def sync(v)
+        CustomDataloader.call_count += 1
+        old_sync(v)
+      end
+    end
+  end
+
   def setup
     MyCustomExecutor.call_count = 0
     CustomDataloader.call_count = 0
@@ -63,13 +74,13 @@ class GraphQL::Batch::CustomExecutorTest < Minitest::Test
     end
 
     assert_equal 'Shirt', product.title
-    assert promise_call_count > 0
+    assert_equal 1, promise_call_count
   end
 
   def test_custom_executor_class
     query_string = '{ product(id: "1") { id } }'
     Schema.execute(query_string)
 
-    assert promise_call_count > 0
+    assert_equal 1, promise_call_count
   end
 end

--- a/test/custom_executor_test.rb
+++ b/test/custom_executor_test.rb
@@ -14,30 +14,62 @@ class GraphQL::Batch::CustomExecutorTest < Minitest::Test
     end
   end
 
+  class CustomDataloader < GraphQL::Dataloader
+    class << self
+      attr_accessor :call_count
+    end
+    self.call_count = 0
+  end
+
   class Schema < GraphQL::Schema
     query ::QueryType
     mutation ::MutationType
 
-    use GraphQL::Batch, executor_class: MyCustomExecutor
+    if TESTING_DATALOADER
+      use GraphQL::Dataloader
+    else
+      use GraphQL::Batch, executor_class: MyCustomExecutor
+    end
   end
 
   def setup
     MyCustomExecutor.call_count = 0
+    CustomDataloader.call_count = 0
+  end
+
+  def in_batch
+    if TESTING_DATALOADER
+      GraphQL::Dataloader.load do
+        yield
+      end
+    else
+      GraphQL::Batch.batch(executor_class: MyCustomExecutor) do
+        yield
+      end
+    end
+  end
+
+  def promise_call_count
+    if TESTING_DATALOADER
+      CustomDataloader.call_count
+    else
+      MyCustomExecutor.call_count
+    end
   end
 
   def test_batch_accepts_custom_executor
-    product = GraphQL::Batch.batch(executor_class: MyCustomExecutor) do
+    product = in_batch do
       RecordLoader.for(Product).load(1)
     end
 
     assert_equal 'Shirt', product.title
-    assert MyCustomExecutor.call_count > 0
+    assert promise_call_count > 0
   end
 
   def test_custom_executor_class
     query_string = '{ product(id: "1") { id } }'
     Schema.execute(query_string)
 
-    assert MyCustomExecutor.call_count > 0
+    assert promise_call_count > 0
   end
 end

--- a/test/support/loaders.rb
+++ b/test/support/loaders.rb
@@ -1,5 +1,5 @@
 if TESTING_DATALOADER
-  class BaseLoader < GraphQL::Dataloader::Loader
+  class BaseLoader < GraphQL::Dataloader::Source
   end
 else
   class BaseLoader < GraphQL::Batch::Loader

--- a/test/support/loaders.rb
+++ b/test/support/loaders.rb
@@ -1,4 +1,12 @@
-class RecordLoader < GraphQL::Batch::Loader
+if TESTING_DATALOADER
+  class BaseLoader < GraphQL::Dataloader::Loader
+  end
+else
+  class BaseLoader < GraphQL::Batch::Loader
+  end
+end
+
+class RecordLoader < BaseLoader
   def initialize(model)
     @model = model
   end
@@ -13,7 +21,7 @@ class RecordLoader < GraphQL::Batch::Loader
   end
 end
 
-class AssociationLoader < GraphQL::Batch::Loader
+class AssociationLoader < BaseLoader
   def initialize(model, association)
     @model = model
     @association = association
@@ -25,7 +33,7 @@ class AssociationLoader < GraphQL::Batch::Loader
   end
 end
 
-class CounterLoader < GraphQL::Batch::Loader
+class CounterLoader < BaseLoader
   def cache_key(counter_array)
     counter_array.object_id
   end
@@ -35,7 +43,7 @@ class CounterLoader < GraphQL::Batch::Loader
   end
 end
 
-class NilLoader < GraphQL::Batch::Loader
+class NilLoader < BaseLoader
   def self.load
     self.for.load(nil)
   end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -191,12 +191,6 @@ class Schema < GraphQL::Schema
   query QueryType
   mutation MutationType
 
-  if ENV["TESTING_LEGACY_DEFINITION_LAYER"] != "true"
-    use GraphQL::Execution::Interpreter
-    # This probably has no effect, but just to get the full test:
-    use GraphQL::Analysis::AST
-  end
-
   if TESTING_DATALOADER
     use GraphQL::Dataloader
   else

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -26,6 +26,10 @@ class ProductType < GraphQL::Schema::Object
   field :title, String, null: false
   field :images, [ImageType], null: true
 
+  if TESTING_DATALOADER
+    Promise = GraphQL::Execution::Lazy
+  end
+
   def images
     product_image_query = RecordLoader.for(Image).load(object.image_id)
     variant_images_query = AssociationLoader.for(Product, :variants).load(object).then do |variants|
@@ -193,5 +197,9 @@ class Schema < GraphQL::Schema
     use GraphQL::Analysis::AST
   end
 
-  use GraphQL::Batch
+  if TESTING_DATALOADER
+    use GraphQL::Dataloader
+  else
+    use GraphQL::Batch
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'graphql/batch'
 
+TESTING_DATALOADER = !!ENV["TESTING_DATALOADER"]
 require_relative 'support/loaders'
 require_relative 'support/schema'
 require_relative 'support/db'


### PR DESCRIPTION
I want to keep an eye on what changes are required regarding https://github.com/rmosolgo/graphql-ruby/pull/2483. 

TODO: 

- [ ] `loader_test.rb` has a lot of important tests, but doesn't touch GraphQL. Gotta find a way to cover that, too 
- [ ] Some hacks were added for instrumentation. Should I upstream those?